### PR TITLE
fix: organization members api missing org_id filter

### DIFF
--- a/apps/mgmt-api-server/src/modules/organization/organization-member.controller.ts
+++ b/apps/mgmt-api-server/src/modules/organization/organization-member.controller.ts
@@ -38,9 +38,9 @@ export class OrganizationMemberController {
     @Param('org_id') org_id: string,
     @Query() _query: OrganizationMemberPageQueryDto,
   ): Promise<PageDto<OrganizationMemberDto>> {
-    const query = {..._query, org_id };
+    const query = {..._query };
   
-    return await this.organizationMemberService.paginate(ctx, query) as any;
+    return await this.organizationMemberService.paginate(ctx, org_id, query) as any;
   }
 
   @Post('')

--- a/apps/mgmt-api-server/src/modules/tenant/tenant.controller.ts
+++ b/apps/mgmt-api-server/src/modules/tenant/tenant.controller.ts
@@ -97,7 +97,8 @@ export class TenantController {
 
     return await this.organizationMemberService.paginate(
       { tenant },
-      {...query, org_id: req.user.org_id },
+      req.user.org_id,
+      { ...query },
     ) as any;
   }
 

--- a/libs/api/infra-api/src/organization/organization-member.repository.ts
+++ b/libs/api/infra-api/src/organization/organization-member.repository.ts
@@ -4,7 +4,7 @@ import { Page, PageQuery } from "libs/common/src/pagination/pagination.model";
 import { OrganizationMemberModel } from "./organization-member.model";
 
 export interface IOrganizationMemberRepository extends QueryRepository<OrganizationMemberModel> {
-  paginate(ctx: IContext, query: PageQuery): Promise<Page<OrganizationMemberModel>>;
+  paginate(ctx: IContext, org_id: string, query: PageQuery): Promise<Page<OrganizationMemberModel>>;
 
   addRoles(ctx: IContext, member_id: string, role_ids: string[]);
   

--- a/libs/api/infra-api/src/organization/organization-member.service.ts
+++ b/libs/api/infra-api/src/organization/organization-member.service.ts
@@ -15,7 +15,7 @@ export interface IOrganizationMemberService {
 
   delete(ctx: IContext, member_id: string): Promise<void>;
 
-  paginate(ctx: IContext, query: PageQueryDto): Promise<PageDto<OrganizationMemberModel>>;
+  paginate(ctx: IContext, org_id: string, query: PageQueryDto): Promise<PageDto<OrganizationMemberModel>>;
 
   addRoles(ctx: IContext, member_id: string, role_ids: string[]);
   

--- a/libs/core/infra-core/src/organization/organization-member.service.ts
+++ b/libs/core/infra-core/src/organization/organization-member.service.ts
@@ -36,8 +36,8 @@ export class OrganizationMemberService implements IOrganizationMemberService {
     await this.organizationMemberRepository.deleteOne(ctx, id);
   }
 
-  async paginate(ctx: IContext, query: PageQueryDto): Promise<PageDto<OrganizationMemberModel>> {
-    return await this.organizationMemberRepository.paginate(ctx, query);
+  async paginate(ctx: IContext, org_id: string, query: PageQueryDto): Promise<PageDto<OrganizationMemberModel>> {
+    return await this.organizationMemberRepository.paginate(ctx, org_id, query);
   }
 
   async addRoles(ctx: IContext, member_id: string, role_ids: string[]) {

--- a/libs/openapi/management-openapi/src/modules/restful/organization/organization-member.controller.ts
+++ b/libs/openapi/management-openapi/src/modules/restful/organization/organization-member.controller.ts
@@ -93,9 +93,9 @@ export class OrganizationMemberController {
     @Param('org_id') org_id: string,
     @Query() _query: OrganizationMemberPageQueryDto,
   ): Promise<PageDto<OrganizationMemberDto>> {
-    const query = { ..._query, org_id };
+    const query = { ..._query };
 
-    const { meta, items: _items } = await this.organizationMemberService.paginate(ctx, query);
+    const { meta, items: _items } = await this.organizationMemberService.paginate(ctx, org_id, query);
     const items = _items.map(it => plainToClass(OrganizationMemberDto, it));
 
     return plainToClass(PageDto<OrganizationMemberDto>, {

--- a/libs/support/infra-support-typeorm/src/modules/organization/typeorm.organization-member.repository.ts
+++ b/libs/support/infra-support-typeorm/src/modules/organization/typeorm.organization-member.repository.ts
@@ -107,6 +107,7 @@ export class TypeOrmOrganizationMemberRepository
 
   async paginate(
     ctx: IContext,
+    org_id: string,
     query: PageQuery,
   ): Promise<Page<OrganizationMemberModel>> {
     const connection: Connection = await this.repo.connectionManager.get(ctx);
@@ -125,6 +126,10 @@ export class TypeOrmOrganizationMemberRepository
     const qb = orgMemberRepo.createQueryBuilder('org_members');
 
     {
+      qb.where(`${qb.alias}.org_id = :org_id`, {
+        org_id,
+      })
+
       qb.leftJoinAndSelect(
         `${qb.alias}.roles`,
         'organization_member_roles',


### PR DESCRIPTION
Fixed the issue where the org_id condition passed to the OrganizationMemberController in Management API Server is not working